### PR TITLE
Fixed inconsistent path to macOS installation image for virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ From the host Mac, serve the installable image to the guest vm by editing `/etc/
 
 On the host Mac, link the image to the default Apache Web server directory:
 
-	$ sudo ln ~/Desktop/sierra.dmg /Library/WebServer/Documents
+	$ sudo ln ~/sierra.dmg /Library/WebServer/Documents
 
 From the host Mac, start Apache in the foreground:
 


### PR DESCRIPTION
The previous command to convert the macOS image has a different path than _~/Desktop/sierra.dmg_

`$ hdiutil convert -format UDZO /tmp/output.sparseimage -o ~/sierra.dmg`

Adjusted path for consistency if following steps in order to create a virtual machine of Sierra.