### PR TITLE
Use Control-D to stop /dev/random here-file seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The PRNG can be manually seeded with entropy by writing to /dev/random **before*
 To manually seed entropy *before* enabling FileVault:
 
 	$ cat > /dev/random
-	[Type random letters for a long while, then press Control-C]
+	[Type random letters for a long while, then press Control-D]
 
 Enable FileVault with `sudo fdesetup enable` or through **System Preferences** > **Security & Privacy** and reboot.
 


### PR DESCRIPTION
If you use Control-C and don't finish your random data by line break, the here-file will be empty (I am not sure what this does on /dev/random, but worst case scenario it would seed with an empty file which might not be a good idea).