### PR TITLE
Change the path to an SSH configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,7 +1353,7 @@ Finally, WEP protection on wireless networks is [not secure](http://www.howtogee
 
 For outgoing ssh connections, use hardware- or password-protected keys, [set up](http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/) remote hosts and consider [hashing](http://nms.csail.mit.edu/projects/ssh/) them for added privacy.
 
-Here are several recommended [options](https://www.freebsd.org/cgi/man.cgi?query=ssh_config&sektion=5) to add to  `~/.ssh/ssh_config`:
+Here are several recommended [options](https://www.freebsd.org/cgi/man.cgi?query=ssh_config&sektion=5) to add to  `~/.ssh/config`:
 
     Host *
       PasswordAuthentication no


### PR DESCRIPTION
It seems to me that `~/.ssh/ssh_config` was meant to be `~/.ssh/config`.

In [ssh_config man page](http://man.openbsd.org/ssh_config#FILES) only two paths are mentioned: `~/.ssh/config` – per-user configuration file, and `/etc/ssh/ssh_config` – systemwide configuration file.