### PR TITLE
Use system's python for fix-macosx.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ $ curl -O https://fix-macosx.com/fix-macosx.py
 
 $ less fix-macosx.py
 
-$ python fix-macosx.py
+$ /usr/bin/python fix-macosx.py
 All done. Make sure to log out (and back in) for the changes to take effect.
 ```
 


### PR DESCRIPTION
When `python` resolves to a non-system provided python binary like a version obtained from Homebrew, the command would fail because python cannot import Foundation modules.

It's better to be explicit on which python binary to use.