### PR TITLE
Minor Change to Prevent Confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ $ curl "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" | sudo
 $ wc -l /etc/hosts
 31998
 
-$ egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.0|^0 " /etc/hosts
+$ egrep -ve "^#|^255.255.255|^0.0.0.0|^127.0.0.1|^0 " /etc/hosts
 ::1 localhost
 fe80::1%lo0 localhost
 [should not return any other IP addresses]


### PR DESCRIPTION
As currently written to command returns more than just 

`::1 localhost
fe80::1%lo0 localhost`

Changing the 0 to 1, however, yields the results as currently written. This is purely to prevent beginners from getting confused at getting an unexpected output. 