### PR TITLE
Move a file path into a code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1756,7 +1756,11 @@ defaults delete ~/Library/Preferences/com.apple.iTunes.plist StoreUserInfo
 defaults delete ~/Library/Preferences/com.apple.iTunes.plist WirelessBuddyID
 ```
 
-`~/Library/Containers/com.apple.QuickTimePlayerX/Data/Library/Preferences/com.apple.QuickTimePlayerX.plist` contains all media played in QuickTime Player.
+All media played in QuickTime Player can be found in:
+
+```shell
+~/Library/Containers/com.apple.QuickTimePlayerX/Data/Library/Preferences/com.apple.QuickTimePlayerX.plist
+```
 
 Additional metadata may exist in the following files:
 


### PR DESCRIPTION
The page at http://macos.duh.to no longer awkwardly scrolls to the right.

![screenshot 2018-06-19 at 11 36 22 am](https://user-images.githubusercontent.com/11537232/41579550-0d8fab0e-73b5-11e8-9f7a-8771738a2f0d.jpeg)
