### PR TITLE
Fix privoxy config paths for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,10 +1083,12 @@ Privoxy already comes with many good rules, however you can also write your own.
 Download [drduh/config/privoxy/config](https://github.com/drduh/config/blob/master/privoxy/config) and [drduh/config/privoxy/user.action](https://github.com/drduh/config/blob/master/privoxy/user.action) to get started:
 
 ```console
-$ curl -o homebrew/etc/privoxy/config https://raw.githubusercontent.com/drduh/config/master/privoxy/config
+$ curl -o /usr/local/etc/privoxy/config https://raw.githubusercontent.com/drduh/config/master/privoxy/config
 
-$ curl -o homebrew/etc/privoxy/user.action https://raw.githubusercontent.com/drduh/config/master/privoxy/user.action
+$ curl -o /usr/local/etc/privoxy/user.action https://raw.githubusercontent.com/drduh/config/master/privoxy/user.action
 ```
+
+If you installed with Homebrew, make sure to set `confdir /usr/local/etc/privoxy` in `/usr/local/etc/privoxy/config`.
 
 Restart Privoxy and verify traffic is blocked or redirected:
 


### PR DESCRIPTION
Currently, the `curl` command to download the premade config files have the `-o` option set to a wrong directory. 

After testing on my clean install, it appears that the default homebrew directory is `/usr/local/etc/privoxy/`.

Also, in the premade config file, `confdir` is set to `/etc/privoxy` which doesn't exist on macOs installs, and changing it to `/usr/local/etc/privoxy` solve the problem.

Running `brew services restart privoxy` without this change won't show any error and the proxy won't start, but running 

```bash
sudo /usr/local/Cellar/privoxy/3.0.28/sbin/privoxy --no-daemon /usr/local/etc/privoxy/config
``` 
Will show
```bash
2020-05-09 11:23:48.625 0011a651 Fatal error: can't load re_filterfile '/etc/privoxy/default.filter': No such file or directory
```

It it therefore required to manually fix the path in the downloaded `/usr/local/etc/privoxy/config` file.