### PR TITLE
Added swiftGuard, Anti-forensic macOS Application, for physical access threats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1945,7 +1945,7 @@ Keep your Mac physically secure at all times. Don't leave it unattended in publi
 
 A skilled attacker with unsupervised physical access to your computer can infect the boot ROM to install a keylogger and steal your password, for example - see [Thunderstrike](https://trmm.net/Thunderstrike).
 
-To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [usbkill](https://github.com/hephaest0s/usbkill). Both respond to USB events and can immediately shutdown your computer if your device is physically separated from you.
+To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app), [usbkill](https://github.com/hephaest0s/usbkill) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 
 Consider purchasing a [privacy filter](https://www.amazon.com/s/ref=nb_sb_noss_2?url=node%3D15782001&field-keywords=macbook) for your screen to thwart shoulder surfers.
 


### PR DESCRIPTION
I added the macOS OpSec-enhancing/Anti-Forensic Application 'swiftGuard' to the category 'Physical access'. If you think it would fit somewhere else, please feel free to edit.

### Overview
It's an anti-forensic macOS tray application designed to safeguard your system or server by monitoring USB ports. It ensures your device's operational security by automatically initiating either a system shutdown or hibernation if an unauthorized device connects or a connected device is unplugged. It offers the flexibility to whitelist designated devices, to select an action to be executed and to set a countdown timer, allowing to disarm the shutdown process. It's a revival of the well-known [usbkill project](https://github.com/hephaest0s/usbkill) by hephaestos, but with a Graphical User Interface and added functionality.

[swiftGuard on Github](https://github.com/Lennolium/swiftGuard)

### Why?

For non-technical user, using the original usbkill command line tool (see above) is far too difficult. This is the reason for swiftGuard: It offers a nice, clean and intuitive Interface with some additional features, whitelisting and an active development (unlike usbkill, which seems abandoned).

### Screenshots
![Interface](https://github.com/Lennolium/swiftGuard/raw/main/img/screenshots/screenshots.png)


>__Disclaimer:__
>I'm an computer science student and developed this app by myself. I did not want to offensively spam/advertise my work here. _I really think_, it would improve this curated list and help others. 
