### PR TITLE
Update certificate authority section

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 ## Certificate authorities
 
-macOS comes with [over 100](https://support.apple.com/en-us/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/en-us/103247#blocked) when a CA proves to be untrustworthy.
+macOS comes with [over 100](https://support.apple.com/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy.
 
 For more information, see [Cloudflare's intro to TLS certificates](https://www.cloudflare.com/learning/ssl/what-is-an-ssl-certificate/).
 

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy. They also have [strict requirements](https://www.apple.com/certificateauthority/ca_program.html) that trusted CAs have to meet.
 
-For more information, see the [CA/Browser Forum's website](https://cabforum.org/resources/tools/).
+For more information, see the [CA/Browser Forum's website](https://cabforum.org/resources/browser-os-info/).
 
 Inspect system root certificates in **Keychain Access**, under the **System Roots** tab or by using the `security` command line tool and `/System/Library/Keychains/SystemRootCertificates.keychain` file.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This guide is also available in [简体中文](https://github.com/drduh/macOS-Se
     + [Dnsmasq](#dnsmasq)
       - [Test DNSSEC validation](#test-dnssec-validation)
 - [Captive portal](#captive-portal)
--[Certificate authorities](#certificate-authorities)
+- [Certificate authorities](#certificate-authorities)
 - [Web](#web)
   * [Privoxy](#privoxy)
   * [Browser](#browser)

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 ## Certificate authorities
 
-macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy. They also have [strict requirements](https://www.apple.com/certificateauthority/ca_program.html) that trusted CA's have to meet.
+macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy. They also have [strict requirements](https://www.apple.com/certificateauthority/ca_program.html) that trusted CAs have to meet.
 
 For more information, see the [CA/Browser Forum's website](https://cabforum.org/resources/tools/).
 
@@ -832,7 +832,7 @@ You can manually disable certificate authorities through Keychain Access by mark
 
 <img width="450" alt="A certificate authority certificate" src="https://cloud.githubusercontent.com/assets/12475110/19222972/6b7aabac-8e32-11e6-8efe-5d3219575a98.png">
 
-**Warning:** This will cause your browser to give a warning when you visit a site using certificates signed by these CA's and may cause breakage in other software. Don't distrust Apple root certificates or it will cause lots of breakage in macOS!
+**Warning:** This will cause your browser to give a warning when you visit a site using certificates signed by these CAs and may cause breakage in other software. Don't distrust Apple root certificates or it will cause lots of breakage in macOS!
 
 The risk of a [man in the middle](https://wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue TLS certificate is quite low, but still [possible](https://wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
 

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 ## Certificate authorities
 
-macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy.
+macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy. They also have [strict requirements](https://www.apple.com/certificateauthority/ca_program.html) that trusted CA's have to meet.
 
 For more information, see the [CA/Browser Forum's website](https://cabforum.org/resources/tools/).
 

--- a/README.md
+++ b/README.md
@@ -819,6 +819,20 @@ sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.captive.c
 
 Also see [Apple's secret "wispr" request](https://web.archive.org/web/20171008071031/http://blog.erratasec.com/2010/09/apples-secret-wispr-request.html), [How to disable the captive portal window in Mac OS Lion](https://web.archive.org/web/20130407200745/http://www.divertednetworks.net/apple-captiveportal.html) and [An undocumented change to Captive Network Assistant settings in OS X 10.10 Yosemite](https://web.archive.org/web/20170622064304/https://grpugh.wordpress.com/2014/10/29/an-undocumented-change-to-captive-network-assistant-settings-in-os-x-10-10-yosemite/).
 
+## Certificate authorities
+
+macOS comes with [over 100](https://support.apple.com/en-us/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing SSL/TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/en-us/103247#blocked) when a CA proves to be untrustworthy.
+
+Inspect system root certificates in **Keychain Access**, under the **System Roots** tab or by using the `security` command line tool and `/System/Library/Keychains/SystemRootCertificates.keychain` file.
+
+You can manually disable certificate authorities through Keychain Access by marking them as **Never Trust** and closing the window:
+
+<img width="450" alt="A certificate authority certificate" src="https://cloud.githubusercontent.com/assets/12475110/19222972/6b7aabac-8e32-11e6-8efe-5d3219575a98.png">
+
+**Warning:** This will cause your browser to give a warning when you visit a site using certificates signed by these CA's and may cause breakage in other software. Don't distrust Apple root certificates or it will cause lots of breakage in macOS!
+
+The risk of a [man in the middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue SSL certificate is quite low, but still [possible](https://en.wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
+
 ## Web
 
 ### Privoxy

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This guide is also available in [简体中文](https://github.com/drduh/macOS-Se
     + [Dnsmasq](#dnsmasq)
       - [Test DNSSEC validation](#test-dnssec-validation)
 - [Captive portal](#captive-portal)
-- [Certificate authorities](#certificate-authorities)
 - [Web](#web)
   * [Privoxy](#privoxy)
   * [Browser](#browser)

--- a/README.md
+++ b/README.md
@@ -822,7 +822,9 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 ## Certificate authorities
 
-macOS comes with [over 100](https://support.apple.com/en-us/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing SSL/TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/en-us/103247#blocked) when a CA proves to be untrustworthy.
+macOS comes with [over 100](https://support.apple.com/en-us/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/en-us/103247#blocked) when a CA proves to be untrustworthy.
+
+For more information, see [Cloudflare's intro to TLS certificates](https://www.cloudflare.com/learning/ssl/what-is-an-ssl-certificate/).
 
 Inspect system root certificates in **Keychain Access**, under the **System Roots** tab or by using the `security` command line tool and `/System/Library/Keychains/SystemRootCertificates.keychain` file.
 
@@ -832,7 +834,7 @@ You can manually disable certificate authorities through Keychain Access by mark
 
 **Warning:** This will cause your browser to give a warning when you visit a site using certificates signed by these CA's and may cause breakage in other software. Don't distrust Apple root certificates or it will cause lots of breakage in macOS!
 
-The risk of a [man in the middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue SSL certificate is quite low, but still [possible](https://en.wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
+The risk of a [man in the middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue TLS certificate is quite low, but still [possible](https://en.wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
 
 ## Web
 

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy.
 
-For more information, see [Cloudflare's intro to TLS certificates](https://www.cloudflare.com/learning/ssl/what-is-an-ssl-certificate/).
+For more information, see the [CA/Browser Forum's website](https://cabforum.org/resources/tools/).
 
 Inspect system root certificates in **Keychain Access**, under the **System Roots** tab or by using the `security` command line tool and `/System/Library/Keychains/SystemRootCertificates.keychain` file.
 

--- a/README.md
+++ b/README.md
@@ -820,21 +820,6 @@ sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.captive.c
 
 Also see [Apple's secret "wispr" request](https://web.archive.org/web/20171008071031/http://blog.erratasec.com/2010/09/apples-secret-wispr-request.html), [How to disable the captive portal window in Mac OS Lion](https://web.archive.org/web/20130407200745/http://www.divertednetworks.net/apple-captiveportal.html) and [An undocumented change to Captive Network Assistant settings in OS X 10.10 Yosemite](https://web.archive.org/web/20170622064304/https://grpugh.wordpress.com/2014/10/29/an-undocumented-change-to-captive-network-assistant-settings-in-os-x-10-10-yosemite/).
 
-
-## Certificate authorities
-
-macOS comes with [over 200](https://support.apple.com/en-us/HT202858) root authority certificates installed from for-profit corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing SSL/TLS certificates for any domain, code signing certificates, etc.
-
-For more information, see [Certification Authority Trust Tracker](https://github.com/kirei/catt), [Analysis of the HTTPS certificate ecosystem](https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf) (pdf), and [You Won’t Be Needing These Any More: On Removing Unused Certificates From Trust Stores](https://www.ifca.ai/fc14/papers/fc14_submission_100.pdf) (pdf).
-
-Inspect system root certificates in **Keychain Access**, under the **System Roots** tab or by using the `security` command line tool and `/System/Library/Keychains/SystemRootCertificates.keychain` file.
-
-Disable certificate authorities through Keychain Access by marking them as **Never Trust** and closing the window:
-
-<img width="450" alt="A certificate authority certificate" src="https://cloud.githubusercontent.com/assets/12475110/19222972/6b7aabac-8e32-11e6-8efe-5d3219575a98.png">
-
-The risk of a [man in the middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue SSL certificate is quite low, but still [possible](https://en.wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
-
 ## Web
 
 ### Privoxy

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Also see [Apple's secret "wispr" request](https://web.archive.org/web/2017100807
 
 ## Certificate authorities
 
-macOS comes with [over 100](https://support.apple.com/HT202858) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy.
+macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy.
 
 For more information, see [Cloudflare's intro to TLS certificates](https://www.cloudflare.com/learning/ssl/what-is-an-ssl-certificate/).
 
@@ -834,7 +834,7 @@ You can manually disable certificate authorities through Keychain Access by mark
 
 **Warning:** This will cause your browser to give a warning when you visit a site using certificates signed by these CA's and may cause breakage in other software. Don't distrust Apple root certificates or it will cause lots of breakage in macOS!
 
-The risk of a [man in the middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue TLS certificate is quite low, but still [possible](https://en.wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
+The risk of a [man in the middle](https://wikipedia.org/wiki/Man-in-the-middle_attack) attack in which a coerced or compromised certificate authority trusted by your system issues a fake/rogue TLS certificate is quite low, but still [possible](https://wikipedia.org/wiki/DigiNotar#Issuance_of_fraudulent_certificates).
 
 ## Web
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This guide is also available in [简体中文](https://github.com/drduh/macOS-Se
     + [Dnsmasq](#dnsmasq)
       - [Test DNSSEC validation](#test-dnssec-validation)
 - [Captive portal](#captive-portal)
+-[Certificate authorities](#certificate-authorities)
 - [Web](#web)
   * [Privoxy](#privoxy)
   * [Browser](#browser)


### PR DESCRIPTION
I think it would be best to remove this part. It's mainly going to cause a lot of breakage/warnings in the browser and everywhere else for little or no benefit. The example given is distrusting the government? So if you go to a government site, at best you get a browser warning, defeating the entire point of certificate authorities in the first place because you won't know if there's a real certificate error or not. Also, one of the examples given is Apple certificates. Well, if you distrust Apple, it causes a lot of breakage and you basically can't use your OS anymore. I'm talking no more updates, no App Store, nothing that requires a connection to Apple will work. Why? Makes no sense to recommend that. If you don't trust Apple then you really shouldn't be using their OS. I've seen with my own eyes people who distrust all the root certificates in their OS and then think they are getting MITM'd because they keep getting a warning in their browser. Best to just axe this part as it might be actively harmful.