### PR TITLE
Update captive portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This guide is also available in [简体中文](https://github.com/drduh/macOS-Se
     + [dnscrypt](#dnscrypt)
     + [Dnsmasq](#dnsmasq)
       - [Test DNSSEC validation](#test-dnssec-validation)
-- [Captive portal](#captive-portal)
 - [Certificate authorities](#certificate-authorities)
 - [Web](#web)
   * [Privoxy](#privoxy)
@@ -558,16 +557,6 @@ Test DNSSEC validation fails for zones that are signed improperly - the reply sh
 $ dig www.dnssec-failed.org
 ;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 15190
 ;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
-```
-
-## Captive portal
-
-When macOS connects to new networks, it checks for Internet connectivity and may launch a Captive Portal assistant utility application.
-
-It is possible to trigger the utility and direct a Mac to malware without user interaction, so it's best to disable this feature and log in to captive portals using your regular Web browser by navigating to a non-secure HTTP page and accepting a redirect to the captive portal login interface (after disabling any custom proxy or DNS settings).
-
-```console
-sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.captive.control.plist Active -bool false
 ```
 
 ## Certificate authorities

--- a/README.md
+++ b/README.md
@@ -570,8 +570,6 @@ It is possible to trigger the utility and direct a Mac to malware without user i
 sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.captive.control.plist Active -bool false
 ```
 
-Also see [Apple's secret "wispr" request](https://web.archive.org/web/20171008071031/http://blog.erratasec.com/2010/09/apples-secret-wispr-request.html), [How to disable the captive portal window in Mac OS Lion](https://web.archive.org/web/20130407200745/http://www.divertednetworks.net/apple-captiveportal.html) and [An undocumented change to Captive Network Assistant settings in OS X 10.10 Yosemite](https://web.archive.org/web/20170622064304/https://grpugh.wordpress.com/2014/10/29/an-undocumented-change-to-captive-network-assistant-settings-in-os-x-10-10-yosemite/).
-
 ## Certificate authorities
 
 macOS comes with [over 100](https://support.apple.com/103723) root authority certificates installed from corporations like Apple, Verisign, Thawte, Digicert and government agencies from China, Japan, Netherlands, U.S., and more! These Certificate Authorities (CAs) are capable of issuing TLS certificates for any domain, code signing certificates, etc. Apple [blocks these certificates](https://support.apple.com/103247#blocked) when a CA proves to be untrustworthy. They also have [strict requirements](https://www.apple.com/certificateauthority/ca_program.html) that trusted CAs have to meet.


### PR DESCRIPTION
- removed outdated archived links
- remove captive portal

I'm kinda skeptical of the usefulness of this one. Won't this just cause problems with captive networks? Apple's got some [nice features](https://developer.apple.com/news/?id=q78sq5rv) to make the captive portal experience better. I know it mentions malware, but it's basically just opening in Safari and web browsers are sandboxed and hardened against malware anyway since they're designed to constantly run untrusted code. Especially now with lockdown mode, safari can be made quite secure. Feel like it's probably better to just leave this one default, seems like it will mostly just cause issues and not really solve anything. Thoughts?