### PR TITLE
Update Physical Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1404,13 +1404,17 @@ sudo lsof -Pni TCP:22
 
 Keep your Mac physically secure at all times and do not leave it unattended in public.
 
-A skilled attacker with unsupervised physical access can infect the boot ROM to install a keylogger and steal passwords. See [Thunderstrike](https://trmm.net/Thunderstrike) for example.
+A skilled attacker could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these devices are designed to be plugged in between a USB keyboard and your computer.
 
-To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app), [usbkill](https://github.com/hephaest0s/usbkill) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
+To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 
 Consider purchasing a privacy screen/filter for use in public.
 
-Superglue or epoxy resin can be used to disable physical access to peripheral ports. [Nail polish](https://trmm.net/Glitter) and tamper-evidence seals can be applied to components to detect tampering.
+Superglue or epoxy resin can be used to disable physical access to peripheral ports. 
+
+**Warning:** This will damage your ports so be 100% sure you'll never need to use them.
+
+[Nail polish](https://trmm.net/Glitter) and tamper-evidence seals can be applied to components to detect tampering.
 
 ## System monitoring
 

--- a/README.md
+++ b/README.md
@@ -1404,7 +1404,7 @@ sudo lsof -Pni TCP:22
 
 Keep your Mac physically secure at all times and do not leave it unattended in public.
 
-A skilled attacker could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these devices are designed to be plugged in between a USB keyboard and your computer.
+A skilled attacker could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
 
 To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 

--- a/README.md
+++ b/README.md
@@ -1410,10 +1410,6 @@ To protect against physical theft during use, you can use an anti-forensic tool 
 
 Consider purchasing a privacy screen/filter for use in public.
 
-Superglue or epoxy resin can be used to disable physical access to peripheral ports. 
-
-**Warning:** This will damage your ports so be 100% sure you'll never need to use them!
-
 [Nail polish](https://trmm.net/Glitter) and tamper-evidence seals can be applied to components to detect tampering.
 
 ## System monitoring

--- a/README.md
+++ b/README.md
@@ -1412,7 +1412,7 @@ Consider purchasing a privacy screen/filter for use in public.
 
 Superglue or epoxy resin can be used to disable physical access to peripheral ports. 
 
-**Warning:** This will damage your ports so be 100% sure you'll never need to use them.
+**Warning:** This will damage your ports so be 100% sure you'll never need to use them!
 
 [Nail polish](https://trmm.net/Glitter) and tamper-evidence seals can be applied to components to detect tampering.
 

--- a/README.md
+++ b/README.md
@@ -1404,7 +1404,7 @@ sudo lsof -Pni TCP:22
 
 Keep your Mac physically secure at all times and do not leave it unattended in public.
 
-A skilled attacker with unsupervised physical access could install a [hardware keylogger](https://trmm.net/Thunderstrike_31c3) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
+A skilled attacker with unsupervised physical access could install a [hardware keylogger](https://trmm.net/Thunderstrike_31c3) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many off-the-shelf versions of this attack are designed to be plugged in between a USB keyboard and your computer.
 
 To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 

--- a/README.md
+++ b/README.md
@@ -1404,7 +1404,7 @@ sudo lsof -Pni TCP:22
 
 Keep your Mac physically secure at all times and do not leave it unattended in public.
 
-A skilled attacker with unsupervised physical access could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
+A skilled attacker with unsupervised physical access could install a [hardware keylogger](https://trmm.net/Thunderstrike_31c3) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
 
 To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 

--- a/README.md
+++ b/README.md
@@ -1404,7 +1404,7 @@ sudo lsof -Pni TCP:22
 
 Keep your Mac physically secure at all times and do not leave it unattended in public.
 
-A skilled attacker could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
+A skilled attacker with unsupervised physical access could install a [hardware keylogger](https://en.wikipedia.org/wiki/Hardware_keylogger) to record all of your keystrokes. Using a Mac with a built-in keyboard or a bluetooth keyboard makes this more difficult as many of these off-the-shelf devices are designed to be plugged in between a USB keyboard and your computer.
 
 To protect against physical theft during use, you can use an anti-forensic tool like [BusKill](https://github.com/buskill/buskill-app) or [swiftGuard](https://github.com/Lennolium/swiftGuard) (updated usbkill, with graphical user interface). All respond to USB events and can immediately shutdown your computer if your device is physically separated from you or an unauthorized device is connected.
 


### PR DESCRIPTION
- removed part about flashing the boot ROM as this isn't possible on Apple silicon Macs and reference to thunderstrike attack which doesn't work on apple silicon
- added hardware key loggers
- removed usbkill as it hasn't been updated in 8 years
- remove destructive superglue/epoxy recommendation