### PR TITLE
Remove OpenBSM audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ To suggest an improvement, send a pull request or [open an issue](https://github
 - [SSH](#ssh)
 - [Physical access](#physical-access)
 - [System monitoring](#system-monitoring)
-   * [OpenBSM audit](#openbsm-audit)
    * [DTrace](#dtrace)
    * [Execution](#execution)
    * [Network](#network)
@@ -1415,25 +1414,6 @@ Consider purchasing a privacy screen/filter for use in public.
 [Nail polish](https://trmm.net/Glitter) and tamper-evidence seals can be applied to components to detect tampering.
 
 # System monitoring
-
-## OpenBSM audit
-
-macOS has a powerful OpenBSM (Basic Security Module) auditing capability. You can use it to monitor process execution, network activity, and much more.
-
-To tail audit logs, use the `praudit` utility:
-
-```console
-$ sudo praudit -l /dev/auditpipe
-header,201,11,execve(2),0,Thu Sep  1 12:00:00 2015, + 195 msec,exec arg,/Applications/.evilapp/rootkit,path,/Applications/.evilapp/rootkit,path,/Applications/.evilapp/rootkit,attribute,100755,root,wheel,16777220,986535,0,subject,drduh,root,wheel,root,wheel,412,100005,50511731,0.0.0.0,return,success,0,trailer,201,
-header,88,11,connect(2),0,Thu Sep  1 12:00:00 2015, + 238 msec,argument,1,0x5,fd,socket-inet,2,443,173.194.74.104,subject,drduh,root,wheel,root,wheel,326,100005,50331650,0.0.0.0,return,failure : Operation now in progress,4354967105,trailer,88
-header,111,11,OpenSSH login,0,Thu Sep  1 12:00:00 2015, + 16 msec,subject_ex,drduh,drduh,staff,drduh,staff,404,404,49271,::1,text,successful login drduh,return,success,0,trailer,111,
-```
-
-See the manual pages for `audit`, `praudit`, `audit_control` and other files in `/etc/security`
-
-**Note** although `man audit` says the `-s` flag will synchronize the audit configuration, it appears necessary to reboot for changes to take effect.
-
-See articles on [ilostmynotes.blogspot.com](https://ilostmynotes.blogspot.com/2013/10/openbsm-auditd-on-os-x-these-are-logs.html) and [derflounder.wordpress.com](https://derflounder.wordpress.com/2012/01/30/openbsm-auditing-on-mac-os-x/) for more information.
 
 ## DTrace
 


### PR DESCRIPTION
The man pages say all of these commands are deprecated and scheduled for removal.