### PR TITLE
PR for #467

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,19 +426,15 @@ Apple is moving to on-device processing for a lot of Siri functions, but some in
 
 # Homebrew
 
-Consider using [Homebrew](https://brew.sh/) to make software installations easier and to update userland tools.
+If your program isn't available through Apple AppStore you can consider using [Homebrew](https://brew.sh/).
 
-**Note** If you have not already installed Xcode or Command Line Tools, use `xcode-select --install` to download and install them, or check Apple's developer site.
+**Important!** Note that Homebrew asks you to grant “App Management” (or “Full Disk Access”) permission to your terminal. This is a bad idea, as it would make you vulnerable to these attacks again: any non-sandboxed application can execute code with the TCC permissions of your terminal by adding a malicious command to (e.g.) ~/.zshrc. Granting “App Management” or “Full Disk Access” to your terminal should be considered the same as disabling TCC completely.
 
-Homebrew uses SSL/TLS to talk with GitHub and verifies integrity of downloaded packages, so it's [fairly secure](https://brew.sh/2022/05/17/homebrew-security-audit/).
-
-Remember to periodically run `brew upgrade` on trusted and secure networks to download and install software updates. To get information on a package before installation, run `brew info <package>` and check its formula online.
+Remember to periodically run `brew upgrade` on trusted and secure networks to download and install software updates. To get information on a package before installation, run `brew info <package>` and check its formula online. You may also wish to enable [additional security options](https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/138), such as `HOMEBREW_NO_INSECURE_REDIRECT=1`
 
 According to [Homebrew's Anonymous Analytics](https://docs.brew.sh/Analytics), Homebrew gathers anonymous analytics and reports these to a self-hosted InfluxDB instance.
-
 To opt out of Homebrew's analytics, you can set `export HOMEBREW_NO_ANALYTICS=1` in your environment or shell rc file, or use `brew analytics off`
 
-You may also wish to enable [additional security options](https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/138), such as `HOMEBREW_NO_INSECURE_REDIRECT=1` and `HOMEBREW_CASK_OPTS=--require-sha`
 
 # DNS
 


### PR DESCRIPTION
https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/467

- removed dangerous recommendation
- instructions about Homebrew slightly changed 
- Xcode stuff removed as Homebrew install everything by itself
- "HOMEBREW_CASK_OPTS=--require-sha" removed as looks like it is default already