### PR TITLE
Remove Arq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1373,7 +1373,6 @@ hdiutil eject /Volumes/secretStuff
 Additional applications and services which offer backups include:
 
 * [Tresorit](https://www.tresorit.com)
-* [Arq](https://www.arqbackup.com)
 * [restic](https://restic.github.io)
 
 # Wi-Fi


### PR DESCRIPTION
- requires admin password to install
- unsandboxed, unrestricted
- installs with a .pkg instead of the more secure method of a .dmg with the application inside
- needs payment info after free trial