### PR TITLE
Replace Broken Privoxy Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ brew install privoxy
 brew services start privoxy
 ```
 
-Alternatively, a signed installation package for Privoxy is available from [silvester.org.uk](https://silvester.org.uk/privoxy/Macintosh%20%28OS%20X%29/) or [Sourceforge](https://sourceforge.net/projects/ijbswa/files/Macintosh%20%28OS%20X%29/). The signed package is [more secure](https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/65) than the Homebrew version and receives support from the Privoxy project.
+Alternatively, a signed installation package for Privoxy is available from [their website](https://www.privoxy.org/sf-download-mirror/Macintosh%20%28OS%20X%29/) or [Sourceforge](https://sourceforge.net/projects/ijbswa/files/Macintosh%20%28OS%20X%29/). The signed package is [more secure](https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/65) than the Homebrew version and receives support from the Privoxy project.
 
 By default, Privoxy listens on local TCP port 8118.
 


### PR DESCRIPTION
- replaced broken https://www.silvester.org.uk/privoxy/ link with https://www.privoxy.org/sf-download-mirror/