### PR TITLE
Re-add Pareto Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ drwx------  2 kevin  staff       64 Dec  4 12:27 umask_testing_dir
 * [CISOfy/lynis](https://github.com/CISOfy/lynis) - Cross-platform security auditing tool and assists with compliance testing and system hardening.
 * [Zentral](https://github.com/zentralopensource/zentral) - A log and configuration server for santa and osquery. Run audit and probes on inventory, events, logfiles, combine with point-in-time alerting. A full Framework and Django web server build on top of the elastic stack (formerly known as ELK stack).
 * [osquery](https://github.com/osquery/osquery) - Can be used to retrieve low level system information.  Users can write SQL queries to retrieve system information.
+* [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 
 # Additional resources
 


### PR DESCRIPTION
It seems to have been removed by mistake in a cleanup commit last March: https://github.com/drduh/macOS-Security-and-Privacy-Guide/commit/a07d13a95d1bd79e67808cf689d2478f673688e8

Yes, it's part of a commercial monitoring suite, but the app itself is opensource and free. Exactly like CISOfy/lynis a few lines above, just aimed more at regular users, with a UI app to make security approachable to everyone.