### PR TITLE
Update passwords section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,9 +1329,9 @@ Consider using [Diceware](https://secure.research.vt.edu/diceware/) for memorabl
 
 GnuPG can also be used to manage passwords and other encrypted files (see [drduh/Purse](https://github.com/drduh/Purse) and [drduh/pwd.sh](https://github.com/drduh/pwd.sh)).
 
-Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthN](https://en.wikipedia.org/wiki/WebAuthn), followed by app-based authenticators, and SMS-based codes are weakest.
+Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn), followed by app-based authenticators, and SMS-based codes are weakest.
 
-[YubiKey](https://www.yubico.com/products/) is an affordable hardware token with WebAuthN support. It can also be used to store cryptographic keys for GnuPG encryption and SSH authentication - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide).
+[YubiKey](https://www.yubico.com/products/) is an affordable hardware token with WebAuthn support. It can also be used to store cryptographic keys for GnuPG encryption and SSH authentication - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide).
 
 # Backup
 

--- a/README.md
+++ b/README.md
@@ -1321,7 +1321,9 @@ Generate strong passwords using [`urandom`](https://en.wikipedia.org/wiki//dev/r
 tr -dc '[:graph:]' < /dev/urandom | fold -w 20 | head -1
 ```
 
-The password assistant in **Keychain Access** can also generate secure credentials.
+The built-in **[Passwords](https://support.apple.com/guide/passwords/the-passwords-app-mchl901b1b95/mac)** app can also generate [secure credentials](https://support.apple.com/guide/security/automatic-strong-passwords-secc84c811c4/web).
+
+The **Passwords** app also supports [passkeys](https://fidoalliance.org/passkeys/), FIDO credentials that can replace passwords and are much more secure against phishing and human error. Make sure to use them instead of passwords whenever you can.
 
 Consider using [Diceware](https://secure.research.vt.edu/diceware/) for memorable passwords.
 

--- a/README.md
+++ b/README.md
@@ -1329,7 +1329,7 @@ Consider using [Diceware](https://secure.research.vt.edu/diceware/) for memorabl
 
 GnuPG can also be used to manage passwords and other encrypted files (see [drduh/Purse](https://github.com/drduh/Purse) and [drduh/pwd.sh](https://github.com/drduh/pwd.sh)).
 
-Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn), followed by TOTP, and SMS-based codes are weakest.
+Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn), followed by [TOTP](https://datatracker.ietf.org/doc/html/rfc6238), then [HOTP](https://datatracker.ietf.org/doc/html/rfc4226), and SMS-based codes are weakest.
 
 [YubiKey](https://www.yubico.com/products/) is an affordable hardware token with WebAuthn support. It can also be used to store cryptographic keys for GnuPG encryption and SSH authentication - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide).
 

--- a/README.md
+++ b/README.md
@@ -1329,7 +1329,7 @@ Consider using [Diceware](https://secure.research.vt.edu/diceware/) for memorabl
 
 GnuPG can also be used to manage passwords and other encrypted files (see [drduh/Purse](https://github.com/drduh/Purse) and [drduh/pwd.sh](https://github.com/drduh/pwd.sh)).
 
-Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn), followed by app-based authenticators, and SMS-based codes are weakest.
+Ensure all eligible online accounts have [multi-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) enabled. The strongest form of multi-factor authentication is [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn), followed by TOTP, and SMS-based codes are weakest.
 
 [YubiKey](https://www.yubico.com/products/) is an affordable hardware token with WebAuthn support. It can also be used to store cryptographic keys for GnuPG encryption and SSH authentication - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide).
 

--- a/README.md
+++ b/README.md
@@ -1323,7 +1323,7 @@ tr -dc '[:graph:]' < /dev/urandom | fold -w 20 | head -1
 
 The built-in **[Passwords](https://support.apple.com/guide/passwords/the-passwords-app-mchl901b1b95/mac)** app can also generate [secure credentials](https://support.apple.com/guide/security/automatic-strong-passwords-secc84c811c4/web).
 
-The **Passwords** app also supports [passkeys](https://fidoalliance.org/passkeys/), FIDO credentials that can replace passwords and are much more secure against phishing and human error. Make sure to use them instead of passwords whenever you can.
+The **Passwords** app also supports [passkeys](https://fidoalliance.org/passkeys/), FIDO credentials that can replace passwords and are much more secure against phishing, human error, and data breaches. Make sure to use them instead of passwords whenever you can.
 
 Consider using [Diceware](https://secure.research.vt.edu/diceware/) for memorable passwords.
 

--- a/README.md
+++ b/README.md
@@ -1315,7 +1315,7 @@ Additional metadata may exist in the following files:
 
 # Passwords
 
-The built-in **[Passwords](https://support.apple.com/guide/passwords/the-passwords-app-mchl901b1b95/mac)** app can also generate [secure credentials](https://support.apple.com/guide/security/automatic-strong-passwords-secc84c811c4/web).
+The built-in **[Passwords](https://support.apple.com/guide/passwords/the-passwords-app-mchl901b1b95/mac)** app can generate [secure credentials](https://support.apple.com/guide/security/automatic-strong-passwords-secc84c811c4/web).
 
 The **Passwords** app also supports [passkeys](https://fidoalliance.org/passkeys/), FIDO credentials that can replace passwords and are much more secure against phishing, human error, and data breaches. Make sure to use them instead of passwords whenever you can.
 

--- a/README.md
+++ b/README.md
@@ -1315,12 +1315,6 @@ Additional metadata may exist in the following files:
 
 # Passwords
 
-Generate strong passwords using [`urandom`](https://en.wikipedia.org/wiki//dev/random) and [`tr`](https://linux.die.net/man/1/tr):
-
-```console
-tr -dc '[:graph:]' < /dev/urandom | fold -w 20 | head -1
-```
-
 The built-in **[Passwords](https://support.apple.com/guide/passwords/the-passwords-app-mchl901b1b95/mac)** app can also generate [secure credentials](https://support.apple.com/guide/security/automatic-strong-passwords-secc84c811c4/web).
 
 The **Passwords** app also supports [passkeys](https://fidoalliance.org/passkeys/), FIDO credentials that can replace passwords and are much more secure against phishing, human error, and data breaches. Make sure to use them instead of passwords whenever you can.


### PR DESCRIPTION
- Mention the Passwords app instead of Keychain Access for storing and generating credentials
- Mention passkeys as more secure password replacements
- Changed WebAuthN to WebAuthn in line with the [stylization](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API)
- Change app-based authenticators to TOTP and HOTP, and order them in terms of security
