### PR TITLE
Update Wi-Fi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,7 +1376,7 @@ Most Wi-Fi networks continuously broadcast their network name, called the **serv
 
 As such, avoid connecting to [hidden networks](https://support.apple.com/guide/security/wi-fi-privacy-with-apple-devices-sec31e483abf/web#sec059998a98).
 
-Make sure to avoid setting your home network to hidden. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
+Make sure to avoid setting your home network to hidden and set your security to the maximum your router supports. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
 You can have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
 

--- a/README.md
+++ b/README.md
@@ -1370,10 +1370,6 @@ Additional applications and services which offer backups include:
 
 # Wi-Fi
 
-macOS remembers access points it has connected to. Like all wireless devices, the Mac will broadcast all access point names it remembers (e.g., *MyHomeNetwork*) each time it looks for a network, such as when waking from sleep.
-
-This is a privacy risk, so remove networks from the list in **System Preferences** > **Network** > **Advanced** when they are no longer needed.
-
 Also see [Signals from the Crowd: Uncovering Social Relationships through Smartphone Probes](https://conferences.sigcomm.org/imc/2013/papers/imc148-barberaSP106.pdf) (pdf).
 
 Saved Wi-Fi information (SSID, last connection, etc.) can be found in `/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist`

--- a/README.md
+++ b/README.md
@@ -1378,7 +1378,7 @@ As such, avoid connecting to [hidden networks](https://support.apple.com/guide/s
 
 Make sure to avoid setting your home network to hidden and set your security to the maximum your router supports. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
-You can set your Mac to have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
+You can set your Mac to have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This is indended to reduce tracking across networks and on the same network over time.
 
 # SSH
 

--- a/README.md
+++ b/README.md
@@ -1378,8 +1378,6 @@ As such, avoid connecting to [hidden networks](https://support.apple.com/guide/s
 
 Make sure to avoid setting your home network to hidden. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
-Saved Wi-Fi information (SSID, last connection, etc.) can be found in `/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist`
-
 You can have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
 
 macOS stores Wi-Fi SSIDs and passwords in NVRAM in order for Recovery Mode to access the Internet. Be sure to either clear NVRAM or de-authenticate your Mac from your Apple account, which will clear the NVRAM, before passing a Mac along. Resetting the SMC will clear some of the NVRAM, but not all.

--- a/README.md
+++ b/README.md
@@ -1380,8 +1380,6 @@ Make sure to avoid setting your home network to hidden. Follow Apple's [guidance
 
 You can have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
 
-Finally, WEP protection on wireless networks is [not secure](http://www.howtogeek.com/167783/htg-explains-the-difference-between-wep-wpa-and-wpa2-wireless-encryption-and-why-it-matters/) and you should only connect to **WPA3** protected networks when possible.
-
 # SSH
 
 For outgoing SSH connections, use hardware or password-protected keys, [set up](http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/) remote hosts and consider [hashing](http://nms.csail.mit.edu/projects/ssh/) them for added privacy. See [drduh/config/ssh_config](https://github.com/drduh/config/blob/master/ssh_config) for recommended client options.

--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,11 @@ Additional applications and services which offer backups include:
 
 # Wi-Fi
 
-Most Wi-Fi networks continuously broadcast their network name, called the **service set identifier (SSID)**, allowing devices to passively scan for networks they have already connected to before. However, **hidden** networks don't transmit their SSID, meaning your device has to send a probe with the SSID to connect to it. This can reveal your previously connected networks to an attacker. As such, avoid connecting to [hidden networks](https://support.apple.com/guide/security/wi-fi-privacy-with-apple-devices-sec31e483abf/web#sec059998a98).
+Most Wi-Fi networks continuously broadcast their network name, called the **service set identifier (SSID)**, allowing devices to [passively](https://www.wi-fi.org/knowledge-center/faq/what-are-passive-and-active-scanning) scan for networks they have already connected to before. However, **hidden** networks don't transmit their SSID, meaning your device has to send a probe with the SSID to connect to it. This can reveal your previously connected networks to an attacker. 
+
+>Apple devices automatically detect when a network is hidden. If a network is hidden, the device sends a probe with the SSID included in the request—not otherwise. This helps prevent the device from broadcasting the name of previously hidden networks a user was connected to, thereby further ensuring privacy.
+
+As such, avoid connecting to [hidden networks](https://support.apple.com/guide/security/wi-fi-privacy-with-apple-devices-sec31e483abf/web#sec059998a98).
 
 Make sure to avoid setting your home network to hidden. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 

--- a/README.md
+++ b/README.md
@@ -1378,7 +1378,7 @@ As such, avoid connecting to [hidden networks](https://support.apple.com/guide/s
 
 Make sure to avoid setting your home network to hidden and set your security to the maximum your router supports. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
-You can have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
+You can set your Mac to have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
 
 # SSH
 

--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,9 @@ Additional applications and services which offer backups include:
 
 # Wi-Fi
 
-Also see [Signals from the Crowd: Uncovering Social Relationships through Smartphone Probes](https://conferences.sigcomm.org/imc/2013/papers/imc148-barberaSP106.pdf) (pdf).
+Most Wi-Fi networks continuously broadcast their network name, called the **service set identifier (SSID)**, allowing devices to passively scan for networks they have already connected to before. However, **hidden** networks don't transmit their SSID, meaning your device has to send a probe with the SSID to connect to it. This can reveal your previously connected networks to an attacker. As such, avoid connecting to [hidden networks](https://support.apple.com/guide/security/wi-fi-privacy-with-apple-devices-sec31e483abf/web#sec059998a98).
+
+Make sure to avoid setting your home network to hidden. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
 Saved Wi-Fi information (SSID, last connection, etc.) can be found in `/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist`
 

--- a/README.md
+++ b/README.md
@@ -1380,8 +1380,6 @@ Make sure to avoid setting your home network to hidden. Follow Apple's [guidance
 
 You can have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This will help prevent you from being tracked across networks and on the same network over time.
 
-macOS stores Wi-Fi SSIDs and passwords in NVRAM in order for Recovery Mode to access the Internet. Be sure to either clear NVRAM or de-authenticate your Mac from your Apple account, which will clear the NVRAM, before passing a Mac along. Resetting the SMC will clear some of the NVRAM, but not all.
-
 Finally, WEP protection on wireless networks is [not secure](http://www.howtogeek.com/167783/htg-explains-the-difference-between-wep-wpa-and-wpa2-wireless-encryption-and-why-it-matters/) and you should only connect to **WPA3** protected networks when possible.
 
 # SSH

--- a/README.md
+++ b/README.md
@@ -1376,7 +1376,7 @@ Most Wi-Fi networks continuously broadcast their network name, called the **serv
 
 As such, avoid connecting to [hidden networks](https://support.apple.com/guide/security/wi-fi-privacy-with-apple-devices-sec31e483abf/web#sec059998a98).
 
-Make sure to avoid setting your home network to hidden and set your security to the maximum your router supports. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
+Make sure to avoid setting your home network to hidden and set your security to WPA3 or the highest your router supports. Follow Apple's [guidance](https://support.apple.com/en-us/102766) on how to set up your home Wi-Fi network to be as secure as possible.
 
 You can set your Mac to have a different, [random MAC address](https://support.apple.com/en-gb/guide/mac-help/mchlb1cb3eb4/mac) for each network that rotates over time. This is indended to reduce tracking across networks and on the same network over time.
 


### PR DESCRIPTION
- Added info about hidden networks. According to Apple:
>Apple devices automatically detect when a network is hidden. If a network is hidden, the device sends a probe with the SSID included in the request—not otherwise. This helps prevent the device from broadcasting the name of previously hidden networks a user was connected to, thereby further ensuring privacy.

So it's not accurate to say that all wifi clients broadcast every SSID they've ever connected to, so I removed that part.
- Removed `/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist` as it doesn't actually contain saved SSID's or last connection
- Removed clearing NVRAM. On Apple Silicon Macs, it doesn't seem possible to [clear NVRAM](https://eclecticlight.co/2024/07/30/nvram-in-apple-silicon-macs/) unless you do a full DFU mode factory reset. Additionally, when I checked the contents with the `nvram -p` command, it didn't seem to contain info about my Wifi networks. Doesn't seem worth mentioning.
- Replaced the security recommendation at the bottom with a link to Apple's Wi-Fi network security guide as it has a more complete list of security settings. Recommending to only connect to WPA3 isn't reasonable and only calling out WEP as insecure could lead people to trust WPA1 for example.