### PR TITLE
Add Lockpaw to Related software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1643,6 +1643,7 @@ drwx------  2 kevin  staff       64 Dec  4 12:27 umask_testing_dir
 * [Zentral](https://github.com/zentralopensource/zentral) - A log and configuration server for osquery. Run audit and probes on inventory, events, logfiles, combine with point-in-time alerting. A full Framework and Django web server build on top of the elastic stack (formerly known as ELK stack).
 * [osquery](https://github.com/osquery/osquery) - Can be used to retrieve low level system information.  Users can write SQL queries to retrieve system information.
 * [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
+* [Lockpaw](https://github.com/sorkila/lockpaw) - A MenuBar app to lock and unlock your screen with a hotkey, preventing visual snooping. Open source, no telemetry.
 
 # Additional resources
 


### PR DESCRIPTION
[Lockpaw](https://github.com/sorkila/lockpaw) is an open-source macOS menu bar screen guard that locks and unlocks your display with a global hotkey, preventing visual snooping.

- Built with Swift, MIT licensed, no telemetry
- 47+ GitHub stars
- Available via Homebrew (`brew tap sorkila/lockpaw && brew install --cask lockpaw`)
- Sparkle auto-updates with EdDSA signing