### PR TITLE
Add Lockpaw (resubmission of #523)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1643,6 +1643,7 @@ drwx------  2 kevin  staff       64 Dec  4 12:27 umask_testing_dir
 * [Zentral](https://github.com/zentralopensource/zentral) - A log and configuration server for osquery. Run audit and probes on inventory, events, logfiles, combine with point-in-time alerting. A full Framework and Django web server build on top of the elastic stack (formerly known as ELK stack).
 * [osquery](https://github.com/osquery/osquery) - Can be used to retrieve low level system information.  Users can write SQL queries to retrieve system information.
 * [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
+* [Lockpaw](https://github.com/sorkila/lockpaw) - A MenuBar app to cover and lock your screen with a hotkey without sleeping - sessions keep running while keyboard input is blocked, Touch ID to unlock. Open source, no telemetry.
 
 # Additional resources
 


### PR DESCRIPTION
This resubmits #523, which was auto-closed when I accidentally deleted the source fork during a cleanup — apologies for the noise, it was not closed on the merits.

To address the point raised in #523 ("hot corners / the built-in lock already do this"): unlike the built-in lock screen or hot corners, Lockpaw covers the screen **without sleeping the display or killing your session** — builds, SSH sessions, and CLI agents keep running while keyboard input is blocked and the display is covered. New in 1.1, the locked screen also signals when a CLI agent (Claude Code / Codex / Gemini) needs attention. The security-relevant difference is that you can walk away in a shared space without leaving the screen readable or your session dead.

Links: https://getlockpaw.com / https://github.com/sorkila/lockpaw

Free, MIT-licensed, native Swift, no analytics or telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)