### PR TITLE
remove temp dir on exit in printKeychainCerts.sh

### DIFF
--- a/scripts/printKeychainCerts.sh
+++ b/scripts/printKeychainCerts.sh
@@ -81,6 +81,7 @@ main() {
   keychain=$(resolveKeychain "${1:-rootca}") || exit 1
 
   workDir=$(mktemp -d)
+  trap 'rm -rf "$workDir"' EXIT
   pemFile="$workDir/certs.pem"
 
   exportCerts "$keychain" "$pemFile"


### PR DESCRIPTION
`printKeychainCerts.sh` creates a temporary directory with `mktemp -d` and fills it with every certificate exported from the keychain (`certs.pem` plus one `cert-N.pem` per certificate), but never removes it, each run leaves the exported certificates behind in `$TMPDIR`.

This adds a `trap ... EXIT` so the directory is removed when the script finishes, whether it exits normally, fails, or is interrupted. It complements the existing `umask 077`, which already restricts access to the temporary files while the script runs.