### PR TITLE
match fingerprint output of openssl 3

### DIFF
--- a/scripts/printKeychainCerts.sh
+++ b/scripts/printKeychainCerts.sh
@@ -63,7 +63,7 @@ certToJson() {
   info=$(openssl x509 -noout -subject -enddate -fingerprint -sha256 -in "$certFile")
   subject=$(echo "$info" | sed -n 's/^subject=[[:space:]]*//p')
   expires=$(echo "$info" | sed -n 's/^notAfter=//p')
-  fingerprint=$(echo "$info" | sed -n 's/^SHA256 Fingerprint=//p')
+  fingerprint=$(echo "$info" | sed -n 's/^[Ss][Hh][Aa]256 Fingerprint=//p')
 
   jq -n --arg subject "$subject" \
         --arg expires "$expires" \


### PR DESCRIPTION
The fingerprint line printed by `openssl x509 -fingerprint` is capitalized differently depending on the OpenSSL flavor:

- LibreSSL (macOS system `/usr/bin/openssl`): `SHA256 Fingerprint=...`
- OpenSSL 3.x (e.g. Homebrew, commonly first in `PATH`): `sha256 Fingerprint=...`

The script matches only the uppercase form, so with OpenSSL 3.x the `sed` extraction finds nothing and every certificate is printed with an empty fingerprint:

```json
{
  "subject": "...",
  "expires": "Nov 27 20:53:42 2026 GMT",
  "sha-256": ""
}
```

This makes the match case-insensitive on the `SHA256` prefix so both flavors work. Tested with LibreSSL 3.3.6 and OpenSSL 3.6.4 on macOS.
