### PR TITLE
refresh vpn section with wireguard instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This guide is provided "as is" - without warranties of any kind. You are solely 
   - [Web browser privacy](#web-browser-privacy)
 - [Tor](#tor)
 - [VPN](#vpn)
+  - [WireGuard](#wireguard)
 - [PGP/GPG](#pgpgpg)
 - [Email](#email)
   - [Thunderbird](#thunderbird)
@@ -999,13 +1000,59 @@ Also see [Invisible Internet Project (I2P)](https://geti2p.net/en/about/intro) a
 
 # VPN
 
-Choose a VPN provider or self-hosted setup with a documented, modern protocol and well-audited clients. Avoid obsolete protocols such as [PPTP](https://en.wikipedia.org/wiki/Point-to-Point_Tunneling_Protocol#Security) in favor of [OpenVPN](https://en.wikipedia.org/wiki/OpenVPN) or [WireGuard](https://www.wireguard.com/) [on a Linux VM](https://github.com/mrash/Wireguard-macOS-LinuxVM) or via a set of [cross platform tools](https://www.wireguard.com/xplatform/).
-
-Some VPN clients may allow traffic to leave over another network interface if the VPN connection drops or is interrupted. See [scy/8122924](https://gist.github.com/scy/8122924) for an example on how to allow traffic only over VPN.
-
-See guides to set up an [IPsec](https://en.wikipedia.org/wiki/Ipsec) VPN on a virtual machine ([hwdsl2/setup-ipsec-vpn](https://github.com/hwdsl2/setup-ipsec-vpn)) or a Docker container ([hwdsl2/docker-ipsec-vpn-server](https://github.com/hwdsl2/docker-ipsec-vpn-server)).
+Choose a VPN provider or self-hosted setup with a documented, modern protocol and well-audited clients. Avoid obsolete protocols such as [PPTP](https://en.wikipedia.org/wiki/Point-to-Point_Tunneling_Protocol#Security) in favor of [WireGuard](https://www.wireguard.com/) or [OpenVPN](https://en.wikipedia.org/wiki/OpenVPN).
 
 It may be worthwhile to consider the geographical location of the VPN provider. See further discussion in [issue 114](https://github.com/drduh/macOS-Security-and-Privacy-Guide/issues/114).
+
+## WireGuard
+
+[WireGuard](https://www.wireguard.com/) is a VPN protocol with a small codebase and a [formally verified](https://www.wireguard.com/formal-verification/) cryptographic design, simpler to configure and audit than IPsec or OpenVPN.
+
+Install the official [WireGuard app](https://apps.apple.com/us/app/wireguard/id1451685025) from the App Store to manage tunnels from the menu bar, or install the command-line tools with Homebrew:
+
+```bash
+brew install wireguard-tools
+```
+
+Generate a key pair for the client:
+
+```bash
+umask 077
+
+wg genkey | tee privatekey | wg pubkey > publickey
+```
+
+Create a tunnel configuration, replacing the keys and addresses with values from your own server or provider:
+
+```
+[Interface]
+PrivateKey = <contents of privatekey>
+Address = 10.8.0.2/32
+DNS = 10.8.0.1
+
+[Peer]
+PublicKey = <server public key>
+AllowedIPs = 0.0.0.0/0, ::/0
+Endpoint = vpn.example.org:51820
+```
+
+`AllowedIPs = 0.0.0.0/0, ::/0` routes all IPv4 and IPv6 traffic through the tunnel; narrower ranges enable split tunneling. See [wg-quick(8)](https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8) for all configuration options.
+
+Import the configuration file into the WireGuard app and enable **On-Demand** so the tunnel activates whenever Wi-Fi or Ethernet is in use. Alternatively, activate the tunnel with the command-line tools:
+
+```bash
+sudo wg-quick up /path/to/wg0.conf
+```
+
+Verify the tunnel is active:
+
+```bash
+sudo wg show
+```
+
+To self-host a WireGuard server, see [trailofbits/algo](https://github.com/trailofbits/algo).
+
+Some VPN clients may allow traffic to leave over another network interface if the VPN connection drops or is interrupted. See [scy/8122924](https://gist.github.com/scy/8122924) for an example on how to allow traffic only over VPN, or use [pf rules](#packet-filter) to restrict traffic to the tunnel interface.
 
 Also see this [technical overview](https://blog.timac.org/2018/0717-macos-vpn-architecture/) of the macOS built-in VPN L2TP/IPsec and [IKEv2](https://en.wikipedia.org/wiki/IKEv2) client.
 


### PR DESCRIPTION
Closes #539.

Refreshes the VPN section with current WireGuard instructions:

- Recommends WireGuard or OpenVPN directly, dropping the 2018-era link for running WireGuard in a Linux VM (native options exist now)
- New **WireGuard** subsection: install via the App Store app or `wireguard-tools` from Homebrew (which pulls in `wireguard-go`, so `wg-quick` works standalone), key generation with `umask 077`, an example tunnel configuration with a note on `AllowedIPs` and split tunneling, On-Demand activation in the app or `wg-quick up` on the command line, verification with `wg show`
- Self-hosting pointer to [trailofbits/algo](https://github.com/trailofbits/algo)
- The traffic-leak paragraph now also points to the guide's own [Packet filter](#packet-filter) section
- Kept the provider-location discussion and the macOS built-in VPN client overview

One deliberate removal to flag: the paragraph linking the hwdsl2 IPsec VM/Docker setup guides is gone, since the refreshed section steers self-hosting toward WireGuard instead. Happy to restore it if you prefer to keep IPsec alternatives listed.

All links in the new text were checked and the commands verified on macOS.
